### PR TITLE
Revert "Use thread_local for storing ThreadId" from vendored v8

### DIFF
--- a/deps/v8/src/base/platform/platform.h
+++ b/deps/v8/src/base/platform/platform.h
@@ -554,7 +554,13 @@ class V8_BASE_EXPORT Thread {
   static LocalStorageKey CreateThreadLocalKey();
   static void DeleteThreadLocalKey(LocalStorageKey key);
   static void* GetThreadLocal(LocalStorageKey key);
+  static int GetThreadLocalInt(LocalStorageKey key) {
+    return static_cast<int>(reinterpret_cast<intptr_t>(GetThreadLocal(key)));
+  }
   static void SetThreadLocal(LocalStorageKey key, void* value);
+  static void SetThreadLocalInt(LocalStorageKey key, int value) {
+    SetThreadLocal(key, reinterpret_cast<void*>(static_cast<intptr_t>(value)));
+  }
   static bool HasThreadLocal(LocalStorageKey key) {
     return GetThreadLocal(key) != nullptr;
   }

--- a/deps/v8/src/execution/thread-id.cc
+++ b/deps/v8/src/execution/thread-id.cc
@@ -11,7 +11,8 @@ namespace internal {
 
 namespace {
 
-thread_local int thread_id = 0;
+DEFINE_LAZY_LEAKY_OBJECT_GETTER(base::Thread::LocalStorageKey, GetThreadIdKey,
+                                base::Thread::CreateThreadLocalKey())
 
 std::atomic<int> next_thread_id{1};
 
@@ -19,14 +20,18 @@ std::atomic<int> next_thread_id{1};
 
 // static
 ThreadId ThreadId::TryGetCurrent() {
+  int thread_id = base::Thread::GetThreadLocalInt(*GetThreadIdKey());
   return thread_id == 0 ? Invalid() : ThreadId(thread_id);
 }
 
 // static
 int ThreadId::GetCurrentThreadId() {
+  auto key = *GetThreadIdKey();
+  int thread_id = base::Thread::GetThreadLocalInt(key);
   if (thread_id == 0) {
     thread_id = next_thread_id.fetch_add(1);
     CHECK_LE(1, thread_id);
+    base::Thread::SetThreadLocalInt(key, thread_id);
   }
   return thread_id;
 }


### PR DESCRIPTION
This allows fibers to find thread_ids

https://app.asana.com/0/1206246080647551/1206281938708349/f

Test plan:
it looks like the Github workflows on this PR are pretty good!
- [x] run fibers on linux with this build
