### PR TITLE
expose process.binding('util').getPromiseDetails

### DIFF
--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -155,7 +155,16 @@ const experimentalModuleList = new SafeSet();
           'DEP0111');
       }
       if (legacyWrapperList.has(module)) {
-        return requireBuiltin('internal/legacy/processbinding')[module]();
+        const legacy = requireBuiltin('internal/legacy/processbinding')[module]();
+        if (module === 'util') {
+          // We need getPromiseDetails and constants.kFulfilled from `internalBinding('util')`
+          return {
+            ...legacy,
+            ...internalBinding('util'),
+          };
+        } else {
+          return legacy;
+        }
       }
       return internalBinding(module);
     }

--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -162,9 +162,8 @@ const experimentalModuleList = new SafeSet();
             ...legacy,
             ...internalBinding('util'),
           };
-        } else {
-          return legacy;
         }
+        return legacy;
       }
       return internalBinding(module);
     }

--- a/test/parallel/test-process-binding-util.js
+++ b/test/parallel/test-process-binding-util.js
@@ -38,7 +38,7 @@ assert.deepStrictEqual(
     'privateSymbols',
     'shouldAbortOnUncaughtToggle',
     'sleep',
-    'toUSVString'
+    'toUSVString',
   ]);
 
 for (const k of Object.keys(utilBinding)) {

--- a/test/parallel/test-process-binding-util.js
+++ b/test/parallel/test-process-binding-util.js
@@ -7,8 +7,19 @@ const utilBinding = process.binding('util');
 assert.deepStrictEqual(
   Object.keys(utilBinding).sort(),
   [
+    'WeakReference',
+    'arrayBufferViewHasBuffer',
+    'constants',
+    'getCallerLocation',
+    'getConstructorName',
+    'getExternalValue',
+    'getOwnNonIndexProperties',
+    'getPromiseDetails',
+    'getProxyDetails',
+    'guessHandleType',
     'isAnyArrayBuffer',
     'isArrayBuffer',
+    'isArrayBufferDetached',
     'isArrayBufferView',
     'isAsyncFunction',
     'isDataView',
@@ -23,8 +34,15 @@ assert.deepStrictEqual(
     'isSetIterator',
     'isTypedArray',
     'isUint8Array',
+    'previewEntries',
+    'privateSymbols',
+    'shouldAbortOnUncaughtToggle',
+    'sleep',
+    'toUSVString'
   ]);
 
 for (const k of Object.keys(utilBinding)) {
-  assert.strictEqual(utilBinding[k], util.types[k]);
+  if (k in util.types) {
+    assert.strictEqual(utilBinding[k], util.types[k]);
+  }
 }


### PR DESCRIPTION
This merges the internalBinding for util and the Node 16+ external binding. Some methods are defined in both
and I haven't checked very carefully what happens with those, but they are all isType methods (eg isPromise)
so it would be pretty buggy if their behavior differed.

test plan:
build node, and verify I can access getPromiseDetails and use it to check if a promise is resolved

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
