### PR TITLE
Add workflow_dispatch trigger to build-node workflow

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -1,6 +1,7 @@
 name: Build Node
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - v20.18.3


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch:` trigger to the build-node.yml workflow on main branch
- This enables the "Run workflow" button in the GitHub Actions UI

## Why
The manual trigger button only appears in GitHub Actions when the workflow has `workflow_dispatch:` on the default branch (main).

## Test plan
- [ ] Verify the "Run workflow" button appears in the Actions tab for the Build Node workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)