### PR TITLE
Add build-node-packages workflow to main

### DIFF
--- a/.github/workflows/build-node-packages.yml
+++ b/.github/workflows/build-node-packages.yml
@@ -1,0 +1,77 @@
+name: Build Node-Packages
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Build Node (Standard)"]
+    types:
+      - completed
+    branches:
+      - v22.21.1
+
+jobs:
+  build-packages:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    strategy:
+      matrix:
+        include:
+          - platform: linux
+            arch: x64
+            runs_on: ubuntu-22.04
+          - platform: linux
+            arch: arm64
+            runs_on: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runs_on }}
+
+    env:
+      NODE_VERSION: v22.21.1
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Debug Matrix Values
+        run: |
+          echo "Matrix platform: ${{ matrix.platform }}"
+          echo "Matrix arch: ${{ matrix.arch }}"
+
+      - name: Download Node archive
+        run: |
+          gh release download node-${{ env.NODE_VERSION }}-release \
+            --repo asana/node \
+            --pattern "node-${{ env.NODE_VERSION }}-${{ matrix.platform }}-${{ matrix.arch }}-LATEST.tar.xz"
+          mv node-${{ env.NODE_VERSION }}-${{ matrix.platform }}-${{ matrix.arch }}-LATEST.tar.xz node.tar.xz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Execute the Dockerfile
+        run: |
+          pwd
+          docker build -t node22_packages_build -f Dockerfile.Packages .
+
+      - name: Extract resources
+        run: |
+          docker create --name temp_node_packages_extract node22_packages_build
+          docker cp temp_node_packages_extract:/usr/src/node/node_modules $GITHUB_WORKSPACE/node_modules
+          docker rm temp_node_packages_extract
+
+      - name: Tar node-packages
+        run: |
+          mkdir -p ./bcrypt@5.1.0/node_modules
+          mkdir -p ./cld@2.9.1/node_modules
+          mkdir -p ./unix-dgram@2.0.6/node_modules
+          mkdir -p "./@datadog+pprof@5.8.0/node_modules/@datadog"
+          mv node_modules/bcrypt ./bcrypt@5.1.0/node_modules/
+          mv node_modules/cld ./cld@2.9.1/node_modules/
+          mv node_modules/unix-dgram ./unix-dgram@2.0.6/node_modules/
+          mv "node_modules/@datadog/pprof" "./@datadog+pprof@5.8.0/node_modules/@datadog/"
+          tar --hard-dereference -cvzf packages_${{matrix.arch}}.tar.gz bcrypt@5.1.0 cld@2.9.1 unix-dgram@2.0.6 "@datadog+pprof@5.8.0"
+
+      - name: Upload archive to release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: node-${{ env.NODE_VERSION }}-LATEST
+          tag_name: node-${{ env.NODE_VERSION }}-release
+          files: packages_${{matrix.arch}}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build-node-packages.yml` to `main` so that `workflow_dispatch` works on feature branches
- GitHub requires a workflow with `workflow_dispatch` to exist on the default branch (`main`) before it can be manually triggered on other branches

## Test plan
- [ ] Merge this PR
- [ ] Re-run `gh workflow run build-node-packages.yml --repo asana/node --ref v22.21.1-profiler` — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)