### PR TITLE
workflows: swap softprops for gh CLI, add CloudFront reachability check, remove --acl

### DIFF
--- a/.github/workflows/build-node-packages.yml
+++ b/.github/workflows/build-node-packages.yml
@@ -123,9 +123,12 @@ jobs:
           # to asana-oss-cache.asana.biz/* (CloudFront). If the S3 key prefix isn't
           # allowlisted in CloudFront's path_patterns, Bazel fetches will 403.
           # Fail fast here rather than after someone tries to build.
-          URL="https://asana-oss-cache.asana.biz/${S3_KEY}"
-          echo "Checking ${URL}"
-          curl -fsSI "${URL}" || { echo "CloudFront returned an error for ${URL}. Check path_patterns in system_packages.tf."; exit 1; }
+          URL="https://asana-oss-cache.asana.biz/$S3_KEY"
+          echo "Checking $URL"
+          if ! curl -fsSI "$URL"; then
+            echo "CloudFront returned an error for $URL. Check path_patterns in system_packages.tf."
+            exit 1
+          fi
 
       - name: Print tools_repositories.bzl stanza
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build-node-packages.yml
+++ b/.github/workflows/build-node-packages.yml
@@ -30,6 +30,10 @@ jobs:
 
     env:
       NODE_VERSION: v22.21.1
+      PLATFORM: ${{ matrix.platform }}
+      ARCH: ${{ matrix.arch }}
+      BAZEL_ARCH: ${{ matrix.bazel_arch }}
+      REPO: ${{ github.repository }}
 
     steps:
       - name: Checkout repository
@@ -37,17 +41,18 @@ jobs:
 
       - name: Debug Matrix Values
         run: |
-          echo "Matrix platform: ${{ matrix.platform }}"
-          echo "Matrix arch: ${{ matrix.arch }}"
+          echo "Matrix platform: $PLATFORM"
+          echo "Matrix arch: $ARCH"
 
       - name: Download Node archive
-        run: |
-          gh release download node-${{ env.NODE_VERSION }}-release \
-            --repo asana/node \
-            --pattern "node-${{ env.NODE_VERSION }}-${{ matrix.platform }}-${{ matrix.arch }}-LATEST.tar.xz"
-          mv node-${{ env.NODE_VERSION }}-${{ matrix.platform }}-${{ matrix.arch }}-LATEST.tar.xz node.tar.xz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ASSET="node-${NODE_VERSION}-${PLATFORM}-${ARCH}-LATEST.tar.xz"
+          gh release download "node-${NODE_VERSION}-release" \
+            --repo asana/node \
+            --pattern "$ASSET"
+          mv "$ASSET" node.tar.xz
 
       - name: Execute the Dockerfile
         run: |
@@ -70,7 +75,7 @@ jobs:
           mv node_modules/cld ./cld@2.9.1/node_modules/
           mv node_modules/unix-dgram ./unix-dgram@2.0.6/node_modules/
           mv "node_modules/@datadog/pprof" "./@datadog+pprof@5.8.0/node_modules/@datadog/"
-          tar --hard-dereference -cvzf packages_${{matrix.arch}}.tar.gz bcrypt@5.1.0 cld@2.9.1 unix-dgram@2.0.6 "@datadog+pprof@5.8.0"
+          tar --hard-dereference -cvzf "packages_${ARCH}.tar.gz" bcrypt@5.1.0 cld@2.9.1 unix-dgram@2.0.6 "@datadog+pprof@5.8.0"
 
       - name: Upload archive to release
         # Use `gh release upload` (first-party GitHub CLI, pre-installed on runners)
@@ -80,10 +85,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "node-${{ env.NODE_VERSION }}-release" \
-            "packages_${{ matrix.arch }}.tar.gz" \
+          gh release upload "node-${NODE_VERSION}-release" \
+            "packages_${ARCH}.tar.gz" \
             --clobber \
-            --repo "${{ github.repository }}"
+            --repo "$REPO"
 
       # S3 upload is restricted to the protected main branch only. The IAM role
       # (push_node_gyp_packages) trusts only refs/heads/main via OIDC. To upload
@@ -106,15 +111,17 @@ jobs:
           # (disable_confusing_acls = true), which disables ACLs entirely.
           # BlockPublicAcls + IgnorePublicAcls provide additional coverage.
           # Reads come via CloudFront OAC.
-          NODE_MAJOR=$(echo "${{ env.NODE_VERSION }}" | sed 's/^v//' | cut -d. -f1)
-          SHA256=$(sha256sum "packages_${{ matrix.arch }}.tar.gz" | awk '{print $1}')
+          NODE_MAJOR=$(echo "$NODE_VERSION" | sed 's/^v//' | cut -d. -f1)
+          SHA256=$(sha256sum "packages_${ARCH}.tar.gz" | awk '{print $1}')
           SHORT_HASH=${SHA256:0:8}
-          S3_KEY="node-gyp/packages_${{ matrix.bazel_arch }}_node${NODE_MAJOR}-${SHORT_HASH}.tar.gz"
-          echo "Uploading packages_${{ matrix.arch }}.tar.gz to s3://asana-oss-cache/${S3_KEY}"
-          aws s3 cp "packages_${{ matrix.arch }}.tar.gz" "s3://asana-oss-cache/${S3_KEY}"
-          echo "S3_KEY=${S3_KEY}" >> "$GITHUB_ENV"
-          echo "SHA256=${SHA256}" >> "$GITHUB_ENV"
-          echo "NODE_MAJOR=${NODE_MAJOR}" >> "$GITHUB_ENV"
+          S3_KEY="node-gyp/packages_${BAZEL_ARCH}_node${NODE_MAJOR}-${SHORT_HASH}.tar.gz"
+          echo "Uploading packages_${ARCH}.tar.gz to s3://asana-oss-cache/$S3_KEY"
+          aws s3 cp "packages_${ARCH}.tar.gz" "s3://asana-oss-cache/$S3_KEY"
+          {
+            echo "S3_KEY=$S3_KEY"
+            echo "SHA256=$SHA256"
+            echo "NODE_MAJOR=$NODE_MAJOR"
+          } >> "$GITHUB_ENV"
 
       - name: Verify upload is reachable via CloudFront
         if: github.ref == 'refs/heads/main'
@@ -135,6 +142,6 @@ jobs:
         run: |
           echo ""
           echo "=== Update tools_repositories.bzl in codez ==="
-          echo "  name = \"node_gyp_packages_${{ matrix.bazel_arch }}_node${NODE_MAJOR}\","
-          echo "  urls = [\"https://asana-oss-cache.s3.us-east-1.amazonaws.com/${S3_KEY}\"],"
-          echo "  sha256 = \"${SHA256}\","
+          echo "  name = \"node_gyp_packages_${BAZEL_ARCH}_node${NODE_MAJOR}\","
+          echo "  urls = [\"https://asana-oss-cache.s3.us-east-1.amazonaws.com/$S3_KEY\"],"
+          echo "  sha256 = \"$SHA256\","

--- a/.github/workflows/build-node-packages.yml
+++ b/.github/workflows/build-node-packages.yml
@@ -73,13 +73,17 @@ jobs:
           tar --hard-dereference -cvzf packages_${{matrix.arch}}.tar.gz bcrypt@5.1.0 cld@2.9.1 unix-dgram@2.0.6 "@datadog+pprof@5.8.0"
 
       - name: Upload archive to release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: node-${{ env.NODE_VERSION }}-LATEST
-          tag_name: node-${{ env.NODE_VERSION }}-release
-          files: packages_${{matrix.arch}}.tar.gz
+        # Use `gh release upload` (first-party GitHub CLI, pre-installed on runners)
+        # instead of softprops/action-gh-release (one-maintainer third-party action).
+        # Behavior: --clobber overwrites an existing asset with the same name, matching
+        # softprops's default. The release must already exist (created by build-node.yml).
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "node-${{ env.NODE_VERSION }}-release" \
+            "packages_${{ matrix.arch }}.tar.gz" \
+            --clobber \
+            --repo "${{ github.repository }}"
 
       # S3 upload is restricted to the protected main branch only. The IAM role
       # (push_node_gyp_packages) trusts only refs/heads/main via OIDC. To upload
@@ -94,12 +98,38 @@ jobs:
       - name: Upload packages to S3
         if: github.ref == 'refs/heads/main'
         run: |
+          # Upload to s3://asana-oss-cache/node-gyp/... (CloudFront path_patterns entry
+          # added in codez PR #390222 — that must be merged + applied via Spacelift
+          # before this workflow can successfully publish fetchable objects).
+          #
+          # No --acl public-read: the bucket has BucketOwnerEnforced
+          # (disable_confusing_acls = true), which disables ACLs entirely.
+          # BlockPublicAcls + IgnorePublicAcls provide additional coverage.
+          # Reads come via CloudFront OAC.
           NODE_MAJOR=$(echo "${{ env.NODE_VERSION }}" | sed 's/^v//' | cut -d. -f1)
           SHA256=$(sha256sum "packages_${{ matrix.arch }}.tar.gz" | awk '{print $1}')
           SHORT_HASH=${SHA256:0:8}
           S3_KEY="node-gyp/packages_${{ matrix.bazel_arch }}_node${NODE_MAJOR}-${SHORT_HASH}.tar.gz"
           echo "Uploading packages_${{ matrix.arch }}.tar.gz to s3://asana-oss-cache/${S3_KEY}"
-          aws s3 cp "packages_${{ matrix.arch }}.tar.gz" "s3://asana-oss-cache/${S3_KEY}" --acl public-read
+          aws s3 cp "packages_${{ matrix.arch }}.tar.gz" "s3://asana-oss-cache/${S3_KEY}"
+          echo "S3_KEY=${S3_KEY}" >> "$GITHUB_ENV"
+          echo "SHA256=${SHA256}" >> "$GITHUB_ENV"
+          echo "NODE_MAJOR=${NODE_MAJOR}" >> "$GITHUB_ENV"
+
+      - name: Verify upload is reachable via CloudFront
+        if: github.ref == 'refs/heads/main'
+        run: |
+          # Mac Bazel builds rewrite asana-oss-cache.s3.us-east-1.amazonaws.com/*
+          # to asana-oss-cache.asana.biz/* (CloudFront). If the S3 key prefix isn't
+          # allowlisted in CloudFront's path_patterns, Bazel fetches will 403.
+          # Fail fast here rather than after someone tries to build.
+          URL="https://asana-oss-cache.asana.biz/${S3_KEY}"
+          echo "Checking ${URL}"
+          curl -fsSI "${URL}" || { echo "CloudFront returned an error for ${URL}. Check path_patterns in system_packages.tf."; exit 1; }
+
+      - name: Print tools_repositories.bzl stanza
+        if: github.ref == 'refs/heads/main'
+        run: |
           echo ""
           echo "=== Update tools_repositories.bzl in codez ==="
           echo "  name = \"node_gyp_packages_${{ matrix.bazel_arch }}_node${NODE_MAJOR}\","

--- a/stage_for_s3.bash
+++ b/stage_for_s3.bash
@@ -16,14 +16,15 @@ gh release download -p "*.xz"
 echo ""
 echo "=== Native packages (node-gyp) ==="
 echo "These are uploaded to s3://asana-oss-cache/node-gyp/ by the build-node-packages.yml workflow"
-echo "with content-hashed S3 keys. Each build produces an immutable artifact."
+echo "(triggered via workflow_dispatch from main) with content-hashed S3 keys."
+echo "Each build produces an immutable artifact."
 for pkg in packages_*.tar.gz; do
   if [ -f "$pkg" ]; then
     echo "  $pkg: sha256=$(sha256sum "$pkg" | awk '{print $1}')"
     rm "$pkg"
   fi
 done
-echo "No manual action needed for packages — they are already in S3."
+echo "No manual action needed for packages if you've already dispatched build-node-packages.yml from main."
 echo ""
 
 curl "https://asana-oss-cache.s3.us-east-1.amazonaws.com/node-fibers/fibers-5.0.4.pc.tgz"  --output fibers-5.0.4.tar.gz


### PR DESCRIPTION
## Summary

Three follow-up corrections to #17 based on post-merge audit findings:

1. **Remove `--acl public-read` from `aws s3 cp`.** The bucket has `disable_confusing_acls = true` (BucketOwnerEnforced), which disables ACLs entirely. `BlockPublicAcls` + `IgnorePublicAcls` provide additional coverage. The ACL flag is silently ignored. The IAM role (`S3_ACCESS_MODE.PUT`) also doesn't grant `PutObjectAcl`. Reads go via CloudFront OAC, not public-S3.

2. **Replace `softprops/action-gh-release` with `gh release upload` (first-party GitHub CLI).** `gh` is pre-installed on GitHub-hosted runners. Removes a third-party (single-maintainer) supply-chain dependency. `--clobber` matches softprops's default overwrite behavior.

3. **Add a post-upload CloudFront reachability check.** If the CloudFront `path_patterns` allowlist doesn't include the key's prefix, Mac Bazel builds will silently 403. `curl -fsSI` against the CloudFront URL fails the workflow at upload time rather than at consumer-build time.

**S3 path stays `node-gyp/*`** — this PR no longer changes it. The CloudFront allowlist entry for `node-gyp/*` is being added in codez [#390222](https://github.com/Asana/codez/pull/390222).

### Action pinning
Tag-pinned per codez convention (100% of codez workflows use tags, not SHAs).

## Merge prerequisites
- [ ] codez [#390222](https://github.com/Asana/codez/pull/390222) merged AND applied via Spacelift (adds `node-gyp/*` to CloudFront `path_patterns`). Without this, the post-upload CloudFront reachability check will 403.

## Test plan
- [ ] Merge
- [ ] Dispatch `build-node-packages.yml` from `main` (not from a version branch)
- [ ] Confirm "Configure AWS credentials" step succeeds
- [ ] Confirm "Upload packages to S3" step succeeds
- [ ] Confirm "Verify upload is reachable via CloudFront" step returns 200 from `asana-oss-cache.asana.biz`
- [ ] Record the two sha256 hashes + S3 URLs printed by the final step — these go into codez [#388870](https://github.com/Asana/codez/pull/388870)'s `tools_repositories.bzl`

## Risks
- If codez [#390222](https://github.com/Asana/codez/pull/390222) isn't applied via Spacelift yet, the post-upload CloudFront check returns 403. The S3 upload still succeeds (just becomes inaccessible from Macs) — low-blast-radius failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)