### PR TITLE
workflows: check out v22.21.1 so Dockerfile.Packages is present

### DIFF
--- a/.github/workflows/build-node-packages.yml
+++ b/.github/workflows/build-node-packages.yml
@@ -36,8 +36,24 @@ jobs:
       REPO: ${{ github.repository }}
 
     steps:
+      # Check out the v22.21.1 branch (not the workflow's default branch) so that
+      # Dockerfile.Packages and the Node source tree are present. The workflow YAML
+      # itself runs from whichever ref triggered it (main for workflow_dispatch, or
+      # v22.21.1 for workflow_run) — that's what the OIDC subject claim binds to,
+      # and it's how the IAM role's ref_patterns gate works. `ref:` here only
+      # controls which tree gets checked out into $GITHUB_WORKSPACE.
+      #
+      # Security note: v22.21.1 is not a protected branch, so in principle any of
+      # the repo's ~530 collaborators could push a malicious Dockerfile.Packages
+      # and have this workflow build+upload the resulting image. That same risk
+      # already existed for the Node source itself (which also lives on this
+      # branch), so this change does not expand the attack surface. A follow-up
+      # PR will propose a structural fix (branch protection, patch series, or
+      # submodule model) — tracked in our internal project notes.
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ env.NODE_VERSION }}
 
       - name: Debug Matrix Values
         run: |


### PR DESCRIPTION
## Summary

Fixes the `build-node-packages.yml` workflow to actually work when dispatched from `main`.

**The problem:** `actions/checkout@v3` defaults to checking out the ref that triggered the workflow. When dispatched from `main`, it pulls `main` — but `Dockerfile.Packages` and the Node source tree only live on the `v22.21.1` branch, so the `docker build` step fails with:

```
ERROR: failed to build: failed to solve: failed to read dockerfile:
open Dockerfile.Packages: no such file or directory
```

This was always the case but didn't surface until PR #17 added the S3 upload, because the `refs/heads/main` OIDC gate forced dispatch from `main`. Under the original `workflow_run` trigger (which runs on `v22.21.1`), the default checkout happened to grab the right tree.

**The fix:** pin `ref: \${{ env.NODE_VERSION }}` (= `v22.21.1`) on the checkout step. This only affects what gets placed into `$GITHUB_WORKSPACE`; the workflow YAML itself still executes from whichever ref triggered it, so `workflow_ref` (the OIDC subject claim) remains `...@refs/heads/main` and the `push_node_gyp_packages` IAM role gate still works.

## Known security hole (flagged for follow-up)

:warning: **`v22.21.1` is not a protected branch.** In principle, any of the repo's ~530 collaborators could push a malicious `Dockerfile.Packages` to this branch and have the workflow build+upload the resulting tarballs to our public S3 cache.

**This change does not expand the attack surface.** The same ~530 collaborators can already modify the Node source tree on this branch, which is what we compile into the released binaries. The Dockerfile is a lesser attack target than the source itself.

**Why we're shipping this anyway:**
- The structural issue (unprotected version branches with write access for hundreds of collaborators) is pre-existing in the Asana/node fork.
- Blocking this PR on a branch-protection change would block the whole node-gyp → S3 migration, which itself has concrete infra-cost/security benefits (removing 305 MB of mutable binaries from every codez checkout).
- The S3-upload IAM role (`push_node_gyp_packages`) still requires `refs/heads/main` OIDC, so the workflow YAML itself can only be modified through `main` (which IS protected).

**A follow-up PR will propose a structural fix** — options under consideration:
- Add branch protection to `v22.21.1` and other active Node version branches
- Migrate to a patch-series-on-top-of-upstream model (reducing the number of "hot" branches to one)
- Switch codez to consume upstream `nodejs/node` directly via submodule, keeping Asana patches in a small fork

Tracked in internal project notes on the Asana/node fork's structural issues.

## Test plan

- [ ] After merging, dispatch the workflow from `main` via the Actions UI.
- [ ] Confirm the checkout step shows `ref: v22.21.1` in its logs.
- [ ] Confirm the Docker build step succeeds (it was failing on the previous dispatch).
- [ ] Confirm both `packages_x64.tar.gz` and `packages_arm64.tar.gz` upload to `s3://asana-oss-cache/node-gyp/`.
- [ ] Capture the sha256s printed at the end of the job for use in the codez PR (#388870).

🤖 Generated with [Claude Code](https://claude.com/claude-code)