### PR TITLE
workflows: replace softprops/action-gh-release with gh CLI (main)

### DIFF
--- a/.github/workflows/build-node-fibers.yml
+++ b/.github/workflows/build-node-fibers.yml
@@ -79,13 +79,24 @@ jobs:
           tar -czf "$ARCHIVE_NAME" -C "$(dirname "$FIBERS_DIR")" "$(basename "$FIBERS_DIR")"
 
       - name: Upload archive to release
-        # Use `gh release upload` (first-party GitHub CLI, pre-installed on runners)
-        # instead of softprops/action-gh-release (one-maintainer third-party action).
-        # The view-or-create guard is race-safe under the matrix and also handles the
-        # workflow_dispatch case where the release may not yet exist. `--clobber`
-        # overwrites an existing asset with the same name, matching softprops's
-        # default. `gh release edit --title` preserves softprops's behavior of always
-        # re-setting the release name on every upload.
+        # Attach the built node-fibers archive to the same node-${NODE_VERSION}-release
+        # release that hosts the corresponding Node binaries.
+        #
+        # Normally this workflow runs after Build Node via workflow_run, so the
+        # release already exists by the time we get here. But workflow_dispatch can
+        # fire it independently (release may not yet exist), and the matrix still
+        # runs both arms (linux-x64, linux-arm64) in parallel — so both arms can
+        # race to create the release. The view-or-create guard with the trailing
+        # `|| gh release view` tolerates "already exists" from a losing racer and
+        # propagates any other create failure through the final view.
+        #
+        # `--clobber` makes re-uploads idempotent on asset name collisions by
+        # deleting the existing asset before uploading. If the new upload fails
+        # after the delete, just re-run the job to rebuild.
+        #
+        # `gh release edit --title` after upload keeps the release title
+        # deterministically derived from NODE_VERSION, overriding any manual rename
+        # in the GitHub UI.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/build-node-fibers.yml
+++ b/.github/workflows/build-node-fibers.yml
@@ -22,6 +22,7 @@ jobs:
 
     env:
       NODE_VERSION: v20.18.3
+      REPO: ${{ github.repository }}
 
     steps:
       - name: Debug Matrix Values
@@ -78,10 +79,22 @@ jobs:
           tar -czf "$ARCHIVE_NAME" -C "$(dirname "$FIBERS_DIR")" "$(basename "$FIBERS_DIR")"
 
       - name: Upload archive to release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: node-${{ env.NODE_VERSION }}-LATEST
-          tag_name: node-${{ env.NODE_VERSION }}-release
-          files: ${{ env.ARCHIVE_NAME }}
+        # Use `gh release upload` (first-party GitHub CLI, pre-installed on runners)
+        # instead of softprops/action-gh-release (one-maintainer third-party action).
+        # The view-or-create guard is race-safe under the matrix and also handles the
+        # workflow_dispatch case where the release may not yet exist. `--clobber`
+        # overwrites an existing asset with the same name, matching softprops's
+        # default. `gh release edit --title` preserves softprops's behavior of always
+        # re-setting the release name on every upload.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="node-${NODE_VERSION}-release"
+          RELEASE_NAME="node-${NODE_VERSION}-LATEST"
+          if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release create "$TAG" --title "$RELEASE_NAME" --notes "" --repo "$REPO" \
+              || gh release view "$TAG" --repo "$REPO" >/dev/null
+          fi
+          gh release upload "$TAG" "$ARCHIVE_NAME" --clobber --repo "$REPO"
+          gh release edit "$TAG" --title "$RELEASE_NAME" --repo "$REPO"

--- a/.github/workflows/build-node-openssl-fips.yml
+++ b/.github/workflows/build-node-openssl-fips.yml
@@ -149,14 +149,25 @@ jobs:
           path: artifacts/${{ env.NODE_ARCHIVE_LATEST }}
 
       - name: Upload Node archive to release
-        # Use `gh release upload` (first-party GitHub CLI, pre-installed on runners)
-        # instead of softprops/action-gh-release (one-maintainer third-party action).
-        # The view-or-create guard is race-safe under the matrix: if the sibling
-        # job creates the release first, `gh release create` fails and the second
-        # `gh release view` confirms the release now exists. `--clobber` overwrites
-        # an existing asset with the same name, matching softprops's default. The
-        # final `gh release edit --title` preserves softprops's behavior of always
-        # re-setting the release name on every upload.
+        # Publish the FIPS-static Node build to its own release tag
+        # (node-${NODE_VERSION}-fips-static-release), separate from the default
+        # Node release so consumers can select the FIPS variant explicitly rather
+        # than relying on filename conventions inside a shared release.
+        #
+        # This workflow is workflow_dispatch-only, and the matrix has two arms
+        # (linux-x64, linux-arm64) running in parallel — on the first invocation
+        # for a new NODE_VERSION both arms race to create the release. The
+        # view-or-create guard with the trailing `|| gh release view` tolerates
+        # "already exists" from the losing racer and propagates any other create
+        # failure through the final view.
+        #
+        # `--clobber` makes re-uploads idempotent on asset name collisions by
+        # deleting the existing asset before uploading. If the new upload fails
+        # after the delete, just re-run the job.
+        #
+        # `gh release edit --title` after upload keeps the release title
+        # deterministically derived from NODE_VERSION, overriding any manual
+        # rename in the GitHub UI.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/build-node-openssl-fips.yml
+++ b/.github/workflows/build-node-openssl-fips.yml
@@ -46,6 +46,7 @@ jobs:
     env:
       S3_BUCKET: your-bucket-name
       AWS_REGION: us-east-1
+      REPO: ${{ github.repository }}
 
     steps:
       - name: Checkout Node fork
@@ -148,10 +149,24 @@ jobs:
           path: artifacts/${{ env.NODE_ARCHIVE_LATEST }}
 
       - name: Upload Node archive to release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: node-${{ env.NODE_VERSION }}-fips-static-LATEST
-          tag_name: node-${{ env.NODE_VERSION }}-fips-static-release
-          files: ./artifacts/${{ env.NODE_ARCHIVE_LATEST }}
+        # Use `gh release upload` (first-party GitHub CLI, pre-installed on runners)
+        # instead of softprops/action-gh-release (one-maintainer third-party action).
+        # The view-or-create guard is race-safe under the matrix: if the sibling
+        # job creates the release first, `gh release create` fails and the second
+        # `gh release view` confirms the release now exists. `--clobber` overwrites
+        # an existing asset with the same name, matching softprops's default. The
+        # final `gh release edit --title` preserves softprops's behavior of always
+        # re-setting the release name on every upload.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="node-${NODE_VERSION}-fips-static-release"
+          RELEASE_NAME="node-${NODE_VERSION}-fips-static-LATEST"
+          FILE="./artifacts/${NODE_ARCHIVE_LATEST}"
+          if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release create "$TAG" --title "$RELEASE_NAME" --notes "" --repo "$REPO" \
+              || gh release view "$TAG" --repo "$REPO" >/dev/null
+          fi
+          gh release upload "$TAG" "$FILE" --clobber --repo "$REPO"
+          gh release edit "$TAG" --title "$RELEASE_NAME" --repo "$REPO"

--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -98,14 +98,26 @@ jobs:
           path: artifacts/${{ env.NODE_ARCHIVE_LATEST }}
 
       - name: Upload Node archive to release
-        # Use `gh release upload` (first-party GitHub CLI, pre-installed on runners)
-        # instead of softprops/action-gh-release (one-maintainer third-party action).
-        # The view-or-create guard is race-safe under the matrix: if the sibling
-        # job creates the release first, `gh release create` fails and the second
-        # `gh release view` confirms the release now exists. `--clobber` overwrites
-        # an existing asset with the same name, matching softprops's default. The
-        # final `gh release edit --title` preserves softprops's behavior of always
-        # re-setting the release name on every upload.
+        # Publish the built Node archive to the node-${NODE_VERSION}-release release.
+        # This is the first uploader in the pipeline; build-node-packages and
+        # build-node-fibers attach additional artifacts to the same release later.
+        #
+        # Matrix concurrency: both matrix arms (linux-x64, linux-arm64) hit this step
+        # in parallel. On the first run for a new NODE_VERSION the release does not
+        # yet exist, so both arms race to create it. The view-or-create guard with
+        # the trailing `|| gh release view` tolerates "already exists" from the
+        # losing arm (as long as the release now exists); any other create failure
+        # propagates through that second view.
+        #
+        # `--clobber` makes re-uploads idempotent on asset name collisions: an
+        # existing asset with the same name is deleted before the new one uploads.
+        # Acceptable here because the -LATEST assets are always reproducible from
+        # the build inputs; if the upload fails after the delete, just re-run the
+        # job.
+        #
+        # `gh release edit --title` after upload keeps the release title
+        # deterministically derived from NODE_VERSION even if someone renames the
+        # release in the GitHub UI.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -122,9 +122,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          TAG="node-${NODE_VERSION}-release"
-          RELEASE_NAME="node-${NODE_VERSION}-LATEST"
-          FILE="./artifacts/${NODE_ARCHIVE_LATEST}"
+          TAG="node-$NODE_VERSION-release"
+          RELEASE_NAME="node-$NODE_VERSION-LATEST"
+          FILE="./artifacts/$NODE_ARCHIVE_LATEST"
           if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
             gh release create "$TAG" --title "$RELEASE_NAME" --notes "" --repo "$REPO" \
               || gh release view "$TAG" --repo "$REPO" >/dev/null

--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -26,6 +26,7 @@ jobs:
     env:
       S3_BUCKET: your-bucket-name
       AWS_REGION: us-east-1
+      REPO: ${{ github.repository }}
 
     steps:
       - name: Checkout Node fork
@@ -97,10 +98,24 @@ jobs:
           path: artifacts/${{ env.NODE_ARCHIVE_LATEST }}
 
       - name: Upload Node archive to release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: node-${{ env.NODE_VERSION }}-LATEST
-          tag_name: node-${{ env.NODE_VERSION }}-release
-          files: ./artifacts/${{ env.NODE_ARCHIVE_LATEST }}
+        # Use `gh release upload` (first-party GitHub CLI, pre-installed on runners)
+        # instead of softprops/action-gh-release (one-maintainer third-party action).
+        # The view-or-create guard is race-safe under the matrix: if the sibling
+        # job creates the release first, `gh release create` fails and the second
+        # `gh release view` confirms the release now exists. `--clobber` overwrites
+        # an existing asset with the same name, matching softprops's default. The
+        # final `gh release edit --title` preserves softprops's behavior of always
+        # re-setting the release name on every upload.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="node-${NODE_VERSION}-release"
+          RELEASE_NAME="node-${NODE_VERSION}-LATEST"
+          FILE="./artifacts/${NODE_ARCHIVE_LATEST}"
+          if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release create "$TAG" --title "$RELEASE_NAME" --notes "" --repo "$REPO" \
+              || gh release view "$TAG" --repo "$REPO" >/dev/null
+          fi
+          gh release upload "$TAG" "$FILE" --clobber --repo "$REPO"
+          gh release edit "$TAG" --title "$RELEASE_NAME" --repo "$REPO"


### PR DESCRIPTION
## Summary

Supply-chain hardening: `softprops/action-gh-release` is a single-maintainer third-party action pinned to the mutable `@v1` tag. If that account is compromised or the tag is re-pointed, every workflow depending on it runs whatever the new code does. Replacing it with the first-party `gh` CLI (pre-installed on GitHub-hosted runners, maintained by GitHub) removes that dependency from the release-upload path.

This is a follow-up to #18, which migrated `build-node-packages.yml`. It migrates the remaining three workflows that still used `softprops/action-gh-release@v1` on `main`:

- `.github/workflows/build-node.yml`
- `.github/workflows/build-node-fibers.yml`
- `.github/workflows/build-node-openssl-fips.yml`

After this PR: zero references to third-party release-upload actions on `main`.

## Canary + downstream PRs

This is the **canary** PR. It must be merged and end-to-end validated before any of the downstream per-branch PRs:

| branch | PR | files migrated |
|---|---|---|
| **`main`** (this PR) | #20 | build-node, build-node-fibers, build-node-openssl-fips |
| `v22.21.1` | #21 | build-node, build-node-fibers, build-node-openssl-fips, build-node-packages |
| `v22.21.1-profiler` | #22 | build-node, build-node-fibers, build-node-openssl-fips, build-node-packages |
| `v24.13.0` | #23 | build-node, build-node-fibers, build-node-packages |
| `v20.18.3` | #24 | build-node, build-node-fibers, build-node-packages |

Each downstream PR is **draft** and references this PR's validation requirement. They are not yet ready for review.

### Validation steps to complete on this PR before unblocking #21–#24

- [ ] Merge this PR.
- [ ] Manually trigger **Build Node** on `main` via `workflow_dispatch`. Both matrix arms (`linux-x64`, `linux-arm64`) succeed without a race failure on `gh release create`.
- [ ] Verify the asset appears in the `node-${NODE_VERSION}-release` release and that the release title is `node-${NODE_VERSION}-LATEST`.
- [ ] Verify the downstream `Build Node-Packages` (already on `gh` CLI from #18) succeeds end-to-end.
- [ ] Manually trigger **Build node-fibers with prebuilt Node** via `workflow_dispatch`. Verify the fibers archive appears in the same release.
- [ ] Manually trigger **Build Node with options around OpenSSL dynamic linking and FIPS** via `workflow_dispatch` (needs a `BUILD_REF` input). Verify the asset appears in `node-${NODE_VERSION}-fips-static-release` with title `node-${NODE_VERSION}-fips-static-LATEST`.
- [ ] Byte-identity check: download one asset uploaded pre-merge via softprops and one uploaded post-merge via gh CLI; confirm `sha256sum` matches.
- [ ] Concurrency smoke: the matrix runs `linux-x64` and `linux-arm64` in parallel — confirm no step fails when both try to create the release at the same time.

Once all of those pass, mark #21–#24 ready for review and merge them in any order.

## Replacement shape

Each softprops step becomes (shell-quoted, `set -euo pipefail`):

```yaml
- name: Upload <...> archive to release
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    set -euo pipefail
    TAG="node-${NODE_VERSION}-release"
    RELEASE_NAME="node-${NODE_VERSION}-LATEST"
    FILE="./artifacts/${NODE_ARCHIVE_LATEST}"
    if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
      gh release create "$TAG" --title "$RELEASE_NAME" --notes "" --repo "$REPO" \
        || gh release view "$TAG" --repo "$REPO" >/dev/null
    fi
    gh release upload "$TAG" "$FILE" --clobber --repo "$REPO"
    gh release edit "$TAG" --title "$RELEASE_NAME" --repo "$REPO"
```

Each job also picks up `REPO: ${{ github.repository }}` in its job-level `env:`, matching the pattern from #18.

## Behavior deltas vs. softprops/action-gh-release@v1

Based on reading the source of both tools — softprops at the `v1` tag SHA (`de2c0eb8`, `src/main.ts` + `src/github.ts`) and `gh` CLI at the installed v2.90.0 (`pkg/cmd/release/{upload,create}/*.go`).

| # | delta | class | notes |
|---|---|---|---|
| 1 | softprops creates-if-missing in one call; `gh release upload` requires release to exist | replaceable | added `view \|\| create` preamble |
| 2 | softprops has internal 3× retry on create (comment says "presume a race with competing matrix runs"); `gh release create` has no retry | replaceable | `create \|\| view` idiom: the loser of the race falls through via `view` |
| 3 | softprops always deletes-then-uploads on same-name conflict; `gh release upload` default errors, `--clobber` matches softprops | no-op | we pass `--clobber` |
| 4 | softprops always sets `name` on upload (via `updateRelease`); `gh release upload` doesn't touch name | preserved via `gh release edit --title` after upload |
| 5 | softprops `updateRelease` also resets body/draft/prerelease to existing values; `gh release edit` without those flags is a no-op for them | no-op | neither approach modifies body; both leave draft/prerelease false |
| 6 | softprops glob-expands `files:`; `gh release upload` also glob-expands via `GlobPaths` | no-op | all call-sites pass a single explicit filename |
| 7 | softprops logs warning on missing files (opt-in to fail); `gh release upload` fails on missing literal path via `os.Stat` | stricter, beneficial | no action required |
| 8 | tag auto-creation: both create lightweight tag from default-branch HEAD when missing | no-op | identical |
| 9 | retries on upload: softprops has Octokit throttling plugin (1 retry on rate-limit); `gh release upload` retries 3× on 5xx or network error | no-op | gh is slightly more robust |
| 10 | step outputs `url`, `id`, `upload_url`, `assets` are not set by `run:` blocks | no-op | no consumers of these outputs anywhere in the repo |
| 11 | auth: softprops uses `GITHUB_TOKEN`; `gh` accepts either `GH_TOKEN` or `GITHUB_TOKEN` | no-op | we keep `GITHUB_TOKEN` for consistency with #18 |

## Out of scope

- `build-node-packages.yml` is not touched here — #18 already migrated it (with a simpler pattern that omits the `gh release edit --title` postamble, because it's not the first uploader and the title is set by this PR's `build-node.yml` step running earlier in the pipeline). Note that the downstream version-branch PRs (#21–#24) use the **full** pattern on `build-node-packages.yml` because those workflows are not chained off `build-node.yml` via `workflow_run` (they fire directly on push or workflow_dispatch).