### PR TITLE
workflows: replace softprops/action-gh-release with gh CLI (v24.13.0)

### DIFF
--- a/.github/workflows/build-node-fibers.yml
+++ b/.github/workflows/build-node-fibers.yml
@@ -21,6 +21,7 @@ jobs:
 
     env:
       NODE_VERSION: v24.13.0
+      REPO: ${{ github.repository }}
 
     steps:
       - name: Debug Matrix Values
@@ -67,10 +68,32 @@ jobs:
           tar -czf "$ARCHIVE_NAME" -C "$(dirname "$FIBERS_DIR")" "$(basename "$FIBERS_DIR")"
 
       - name: Upload archive to release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: node-${{ env.NODE_VERSION }}-LATEST
-          tag_name: node-${{ env.NODE_VERSION }}-release
-          files: ${{ env.ARCHIVE_NAME }}
+        # Attach the built node-fibers archive to the same node-${NODE_VERSION}-release
+        # release that hosts the corresponding Node binaries.
+        #
+        # This workflow is fired by `push` to v24.13.0 and by workflow_dispatch — it
+        # is not chained off Build Node, so the release may not yet exist. The
+        # matrix runs both arms (linux-x64, linux-arm64) in parallel, so both can
+        # race to create the release. The view-or-create guard with the trailing
+        # `|| gh release view` tolerates "already exists" from a losing racer and
+        # propagates any other create failure through the final view.
+        #
+        # `--clobber` makes re-uploads idempotent on asset name collisions by
+        # deleting the existing asset before uploading. If the new upload fails
+        # after the delete, just re-run the job to rebuild.
+        #
+        # `gh release edit --title` after upload keeps the release title
+        # deterministically derived from NODE_VERSION, overriding any manual rename
+        # in the GitHub UI.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="node-${NODE_VERSION}-release"
+          RELEASE_NAME="node-${NODE_VERSION}-LATEST"
+          if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release create "$TAG" --title "$RELEASE_NAME" --notes "" --repo "$REPO" \
+              || gh release view "$TAG" --repo "$REPO" >/dev/null
+          fi
+          gh release upload "$TAG" "$ARCHIVE_NAME" --clobber --repo "$REPO"
+          gh release edit "$TAG" --title "$RELEASE_NAME" --repo "$REPO"

--- a/.github/workflows/build-node-packages.yml
+++ b/.github/workflows/build-node-packages.yml
@@ -21,6 +21,7 @@ jobs:
 
     env:
       NODE_VERSION: v24.13.0
+      REPO: ${{ github.repository }}
 
     steps:
       - name: Debug Matrix Values
@@ -68,10 +69,33 @@ jobs:
           tar --hard-dereference -cvzf packages_${{matrix.arch}}.tar.gz bcrypt@5.1.0 cld@2.9.1 unix-dgram@2.0.6
 
       - name: Upload archive to release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: node-${{ env.NODE_VERSION }}-LATEST
-          tag_name: node-${{ env.NODE_VERSION }}-release
-          files: packages_${{matrix.arch}}.tar.gz
+        # Attach the built gyp-package bundle to the same node-${NODE_VERSION}-release
+        # release that hosts the corresponding Node binaries.
+        #
+        # This workflow is fired by `push` to v24.13.0 and by workflow_dispatch — it
+        # is not chained off Build Node, so the release may not yet exist. The
+        # matrix runs both arms (linux-x64, linux-arm64) in parallel, so both can
+        # race to create the release. The view-or-create guard with the trailing
+        # `|| gh release view` tolerates "already exists" from a losing racer and
+        # propagates any other create failure through the final view.
+        #
+        # `--clobber` makes re-uploads idempotent on asset name collisions by
+        # deleting the existing asset before uploading. If the new upload fails
+        # after the delete, just re-run the job.
+        #
+        # `gh release edit --title` after upload keeps the release title
+        # deterministically derived from NODE_VERSION, overriding any manual rename
+        # in the GitHub UI.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="node-${NODE_VERSION}-release"
+          RELEASE_NAME="node-${NODE_VERSION}-LATEST"
+          FILE="packages_${{matrix.arch}}.tar.gz"
+          if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release create "$TAG" --title "$RELEASE_NAME" --notes "" --repo "$REPO" \
+              || gh release view "$TAG" --repo "$REPO" >/dev/null
+          fi
+          gh release upload "$TAG" "$FILE" --clobber --repo "$REPO"
+          gh release edit "$TAG" --title "$RELEASE_NAME" --repo "$REPO"

--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -23,6 +23,7 @@ jobs:
     env:
       S3_BUCKET: your-bucket-name
       AWS_REGION: us-east-1
+      REPO: ${{ github.repository }}
 
     steps:
       - name: Checkout Node fork
@@ -85,10 +86,36 @@ jobs:
           path: artifacts/${{ env.NODE_ARCHIVE_LATEST }}
 
       - name: Upload Node archive to release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: node-${{ env.NODE_VERSION }}-LATEST
-          tag_name: node-${{ env.NODE_VERSION }}-release
-          files: ./artifacts/${{ env.NODE_ARCHIVE_LATEST }}
+        # Publish the built Node archive to the node-${NODE_VERSION}-release release.
+        # This is the first uploader in the pipeline; build-node-packages and
+        # build-node-fibers attach additional artifacts to the same release later.
+        #
+        # Matrix concurrency: both matrix arms (linux-x64, linux-arm64) hit this step
+        # in parallel. On the first run for a new NODE_VERSION the release does not
+        # yet exist, so both arms race to create it. The view-or-create guard with
+        # the trailing `|| gh release view` tolerates "already exists" from the
+        # losing arm (as long as the release now exists); any other create failure
+        # propagates through that second view.
+        #
+        # `--clobber` makes re-uploads idempotent on asset name collisions: an
+        # existing asset with the same name is deleted before the new one uploads.
+        # Acceptable here because the -LATEST assets are always reproducible from
+        # the build inputs; if the upload fails after the delete, just re-run the
+        # job.
+        #
+        # `gh release edit --title` after upload keeps the release title
+        # deterministically derived from NODE_VERSION even if someone renames the
+        # release in the GitHub UI.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="node-${NODE_VERSION}-release"
+          RELEASE_NAME="node-${NODE_VERSION}-LATEST"
+          FILE="./artifacts/${NODE_ARCHIVE_LATEST}"
+          if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release create "$TAG" --title "$RELEASE_NAME" --notes "" --repo "$REPO" \
+              || gh release view "$TAG" --repo "$REPO" >/dev/null
+          fi
+          gh release upload "$TAG" "$FILE" --clobber --repo "$REPO"
+          gh release edit "$TAG" --title "$RELEASE_NAME" --repo "$REPO"


### PR DESCRIPTION
## DO NOT MERGE until canary PR #20 (main) is validated

This is part of the rollout of the softprops → gh-CLI migration across all Asana/node branches. **The canary PR on main (#20) must be merged and end-to-end validated first.** Merging this PR before then risks landing a regression on a production release branch with no safety net.

### Validation checklist to complete on main (#20) before touching this PR

- [ ] PR #20 is merged into `main`.
- [ ] Manually trigger **Build Node** on `main` via `workflow_dispatch`. Both matrix arms (`linux-x64`, `linux-arm64`) succeed without a race failure on `gh release create`.
- [ ] The resulting release `node-vX.Y.Z-release` exists with title `node-vX.Y.Z-LATEST`, and both architecture archives appear as assets.
- [ ] Manually trigger **Build Node-Packages** on `main`. Assets appear; release title still correct.
- [ ] Manually trigger **Build node-fibers with prebuilt Node** on `main`. Assets appear; release title still correct.
- [ ] Manually trigger **Build Node with options around OpenSSL dynamic linking and FIPS** on `main` with appropriate `BUILD_REF`. Assets appear in the separate `-fips-static-release` release with the expected title. (Note: this branch has no FIPS workflow, but the FIPS migration on main exercises the same replacement-block shape.)
- [ ] Byte-identity spot-check: compare `sha256sum` of an asset uploaded post-migration on main against one uploaded pre-migration — should match.
- [ ] No release-body or commitish drift observed in any of the above.

Only after all of those pass — mark this PR ready for review and merge.

## Summary

Supply-chain hardening: `softprops/action-gh-release` is a single-maintainer third-party action pinned to the mutable `@v1` tag. Replacing it with the first-party `gh` CLI (pre-installed on GitHub-hosted runners, maintained by GitHub) removes that dependency from the release-upload path.

Migrates all three release-upload call-sites on `v24.13.0`:

- `.github/workflows/build-node.yml`
- `.github/workflows/build-node-fibers.yml`
- `.github/workflows/build-node-packages.yml`

(v24.13.0 has no `build-node-openssl-fips.yml`.)

After this PR: zero references to `softprops/action-gh-release` on `v24.13.0`.

## Replacement shape

Each softprops step becomes:

```yaml
- name: Upload <...> archive to release
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    set -euo pipefail
    TAG="node-${NODE_VERSION}-release"
    RELEASE_NAME="node-${NODE_VERSION}-LATEST"
    FILE="<path-or-shell-expr>"
    if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
      gh release create "$TAG" --title "$RELEASE_NAME" --notes "" --repo "$REPO" \
        || gh release view "$TAG" --repo "$REPO" >/dev/null
    fi
    gh release upload "$TAG" "$FILE" --clobber --repo "$REPO"
    gh release edit "$TAG" --title "$RELEASE_NAME" --repo "$REPO"
```

Each job gains `REPO: ${{ github.repository }}` in its job-level `env:`.

### Note on triggers

On `v24.13.0`, both `build-node-fibers.yml` and `build-node-packages.yml` fire on `push` to v24.13.0 (in addition to `workflow_dispatch`) — they are NOT chained off Build Node via `workflow_run`. That means each can land in this code path BEFORE `build-node.yml` has run for a given NODE_VERSION, so the view-or-create guard is genuinely necessary on every file (not just on `build-node.yml`). The comments in each file reflect that.

### Divergence from main's post-migration shape

On `main`, `build-node-packages.yml` uses a simpler upload pattern (plain `gh release upload --clobber`, no view-or-create guard, no `gh release edit --title`), under the assumption it always runs downstream of `build-node.yml` (via `workflow_run`). On `v24.13.0` that assumption doesn't hold (push trigger, not workflow_run), so the **full** pattern is the correct choice here — a simpler version would break standalone runs.

## Behavior deltas vs. softprops/action-gh-release@v1

See PR #20 for the full delta table. Summary: 7 no-op deltas, 3 covered by the replacement block (view-or-create, clobber, edit-title), 1 stricter-beneficial (missing-file fails loudly), 1 supply-chain benefit (the point of this work).

## Post-merge test plan for this branch

- [ ] Push to `v24.13.0` (or `workflow_dispatch`) triggers all three workflows. Each succeeds.
- [ ] Assets appear in `node-v24.13.0-release` with title `node-v24.13.0-LATEST`.
- [ ] Spot-check asset `sha256sum` matches pre-migration.